### PR TITLE
Improve stability of OnlineRepository disposing

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -35,7 +35,7 @@
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 [![Release](https://jitpack.io/v/levibostian/Teller-Android.svg)](https://jitpack.io/#levibostian/Teller-Android)
 [![Build](https://app.bitrise.io/app/4c0b872bdaf76300/status.svg?token=PYpJBThARi6LvucXS2noVw&branch=development)](https://app.bitrise.io/app/4c0b872bdaf76300)
-[![Coverage](https://codecov.io/gh/levibostian/Teller-Android/branch/development/graph/badge.svg)](https://codecov.io/gh/levibostian/Teller-Android/)
 
-# Intro 
+# Teller
 
 Android library that makes your apps faster. 
 

--- a/build.gradle
+++ b/build.gradle
@@ -12,11 +12,6 @@ buildscript {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jetbrains.dokka:dokka-android-gradle-plugin:$dokka_version"
 
-        // Generate test reports for code coverage
-        classpath('com.dicedmelon.gradle:jacoco-android:0.1.3') {
-            exclude group: 'org.codehaus.groovy', module: 'groovy-all'
-        }
-
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/docs/home.md
+++ b/docs/home.md
@@ -1,6 +1,5 @@
 [![Release](https://jitpack.io/v/levibostian/Teller-Android.svg)](https://jitpack.io/#levibostian/Teller-Android)
 [![Build](https://app.bitrise.io/app/4c0b872bdaf76300/status.svg?token=PYpJBThARi6LvucXS2noVw&branch=development)](https://app.bitrise.io/app/4c0b872bdaf76300)
-[![Coverage](https://codecov.io/gh/levibostian/Teller-Android/branch/development/graph/badge.svg)](https://codecov.io/gh/levibostian/Teller-Android/)
 
 # Intro 
 

--- a/teller/build.gradle
+++ b/teller/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'org.jetbrains.dokka-android'
-apply plugin: 'jacoco-android'
 
 android {
     compileSdkVersion 28
@@ -22,9 +21,6 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
             multiDexEnabled false
-        }
-        debug {
-            testCoverageEnabled true
         }
     }
     lintOptions {

--- a/teller/src/main/java/com/levibostian/teller/datastate/OnlineDataState.kt
+++ b/teller/src/main/java/com/levibostian/teller/datastate/OnlineDataState.kt
@@ -137,11 +137,7 @@ data class OnlineDataState<CACHE: Any> internal constructor(val noCacheExists: B
     }
 
     override fun toString(): String {
-        return if (stateMachine != null) {
-            stateMachine.toString()
-        } else {
-            "State: none"
-        }
+        return stateMachine?.toString() ?: "State: none"
     }
 
 }

--- a/teller/src/main/java/com/levibostian/teller/repository/manager/OnlineRepositoryRefreshManager.kt
+++ b/teller/src/main/java/com/levibostian/teller/repository/manager/OnlineRepositoryRefreshManager.kt
@@ -16,8 +16,8 @@ internal interface OnlineRepositoryRefreshManager {
      * Listener to get notified when a refresh call has begun and when it completes. This is different from the Observer returned from [refresh]. [Listener] is mostly intended for [OnlineRepository] to know when a refresh is begun and complete so it can notify observers of fetch status and to save new cache data.
      */
     interface Listener {
-        fun refreshBegin()
-        fun <RefreshResultDataType: Any> refreshComplete(response: OnlineRepository.FetchResponse<RefreshResultDataType>)
+        fun refreshBegin(tag: GetDataRequirementsTag)
+        fun <RefreshResultDataType: Any> refreshComplete(tag: GetDataRequirementsTag, response: OnlineRepository.FetchResponse<RefreshResultDataType>)
     }
 
     /**

--- a/teller/src/main/java/com/levibostian/teller/repository/manager/SharedOnlineRepositoryRefreshManager.kt
+++ b/teller/src/main/java/com/levibostian/teller/repository/manager/SharedOnlineRepositoryRefreshManager.kt
@@ -45,7 +45,7 @@ internal object SharedOnlineRepositoryRefreshManager: OnlineRepositoryRefreshMan
             if (repositoryItems == null) {
                 repositoryItems = Repository(ReplaySubject.create<OnlineRepository.RefreshResult>(), WeakReference(repository))
 
-                repository.refreshBegin() // since refresh has already begun, send listener update now.
+                repository.refreshBegin(tag) // since refresh has already begun, send listener update now.
 
                 refreshItem.repositories.add(repositoryItems)
             }
@@ -81,7 +81,7 @@ internal object SharedOnlineRepositoryRefreshManager: OnlineRepositoryRefreshMan
 
         return task.doOnSuccess { response ->
             updateRepositoryListeners(tag) { listener ->
-                listener.refreshComplete(response)
+                listener.refreshComplete(tag, response)
             }
 
             response.failure?.let { fetchFailure ->

--- a/teller/src/main/java/com/levibostian/teller/subject/OnlineDataStateBehaviorSubject.kt
+++ b/teller/src/main/java/com/levibostian/teller/subject/OnlineDataStateBehaviorSubject.kt
@@ -27,15 +27,16 @@ internal class OnlineDataStateBehaviorSubject<CACHE: Any> {
         set(value) {
             synchronized(this) {
                 field = value
-                subject.onNext(dataState)
+
+                if (!subject.hasComplete()) subject.onNext(dataState)
             }
         }
     val subject: BehaviorSubject<OnlineDataState<CACHE>> = BehaviorSubject.createDefault(dataState)
 
-    var currentState: OnlineDataState<CACHE> = OnlineDataState.none()
+    var currentState: OnlineDataState<CACHE>? = null
         get() {
             return synchronized(this) {
-                subject.value!!
+                subject.value
             }
         }
         private set

--- a/teller/src/main/java/com/levibostian/teller/util/TaskExecutor.kt
+++ b/teller/src/main/java/com/levibostian/teller/util/TaskExecutor.kt
@@ -1,6 +1,5 @@
 package com.levibostian.teller.util
 
-
 internal interface TaskExecutor {
     fun postUI(block: () -> Unit)
 }

--- a/teller/src/sharedTest/java/com/levibostian/teller/TestConstants.kt
+++ b/teller/src/sharedTest/java/com/levibostian/teller/TestConstants.kt
@@ -6,5 +6,6 @@ package com.levibostian.teller
  * One place to go to change the whole test suite at one time.
  */
 internal object TestConstants {
+    const val ASYNC_INSTRUMENTATION_TESTS_WAIT_TIME = 200L
     const val RX_TEST_OBSERVER_AWAIT_DONE_TIME = 300L
 }

--- a/teller/src/sharedTest/java/com/levibostian/teller/repository/OnlineRepositoryStub.kt
+++ b/teller/src/sharedTest/java/com/levibostian/teller/repository/OnlineRepositoryStub.kt
@@ -11,7 +11,8 @@ import io.reactivex.Single
 internal class OnlineRepositoryStub(syncStateManager: OnlineRepositorySyncStateManager,
                                     refreshManager: OnlineRepositoryRefreshManager,
                                     schedulersProvider: SchedulersProvider,
-                                    taskExecutor: TaskExecutor): OnlineRepository<String, OnlineRepositoryStub.GetRequirements, String>(syncStateManager, refreshManager, schedulersProvider, taskExecutor) {
+                                    taskExecutor: TaskExecutor,
+                                    refreshManagerListener: OnlineRepositoryRefreshManager.Listener): OnlineRepository<String, OnlineRepositoryStub.GetRequirements, String>(syncStateManager, refreshManager, schedulersProvider, taskExecutor, refreshManagerListener) {
 
     override var maxAgeOfData: AgeOfData = AgeOfData(1, AgeOfData.Unit.HOURS)
 
@@ -28,8 +29,8 @@ internal class OnlineRepositoryStub(syncStateManager: OnlineRepositorySyncStateM
         get() = saveData_results.size
         private set
     override fun saveData(data: String, requirements: GetRequirements) {
-        saveData_invoke?.invoke(data)
         saveData_results.add(data)
+        saveData_invoke?.invoke(data)
     }
 
     var observeCachedData_results = arrayListOf<GetRequirements>()

--- a/teller/src/sharedTest/java/com/levibostian/teller/util/Wait.kt
+++ b/teller/src/sharedTest/java/com/levibostian/teller/util/Wait.kt
@@ -1,0 +1,33 @@
+package com.levibostian.teller.util
+
+import com.levibostian.teller.TestConstants
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+/**
+ * Tiny companion wrapper for [CountDownLatch] to make testing async code easy.
+ */
+class Wait private constructor(val number: Int) {
+
+    private val countdown = CountDownLatch(number)
+    var count: Long = 0
+        get() = countdown.count
+        private set
+
+    companion object {
+        fun times(times: Int): Wait = Wait(times)
+    }
+
+    fun notDone(): Boolean = count > 0
+
+    fun done(): Boolean = !notDone()
+
+    fun countDown() {
+        countdown.countDown()
+    }
+
+    fun await() {
+        countdown.await(TestConstants.ASYNC_INSTRUMENTATION_TESTS_WAIT_TIME, TimeUnit.MILLISECONDS)
+    }
+
+}

--- a/teller/src/test/java/com/levibostian/teller/repository/OnlineRepositoryTest.kt
+++ b/teller/src/test/java/com/levibostian/teller/repository/OnlineRepositoryTest.kt
@@ -10,6 +10,7 @@ import org.junit.Test
 import com.levibostian.teller.util.AssertionUtil.Companion.check
 import com.levibostian.teller.util.TaskExecutor
 import com.nhaarman.mockito_kotlin.any
+import com.nhaarman.mockito_kotlin.eq
 
 import org.junit.runner.RunWith
 import org.mockito.Mock
@@ -35,6 +36,7 @@ class OnlineRepositoryTest {
     @Mock private lateinit var refreshManager: OnlineRepositoryRefreshManager
     @Mock private lateinit var schedulersProvider: SchedulersProvider
     @Mock private lateinit var taskExecutor: TaskExecutor
+    @Mock private lateinit var refreshManagerListener: OnlineRepositoryRefreshManager.Listener
 
     @Before
     fun setup() {
@@ -47,7 +49,7 @@ class OnlineRepositoryTest {
             (it.getArgument(0) as () -> Unit).invoke()
         }
         requirements = OnlineRepositoryStub.GetRequirements()
-        repository = OnlineRepositoryStub(syncStateManager, refreshManager, schedulersProvider, taskExecutor)
+        repository = OnlineRepositoryStub(syncStateManager, refreshManager, schedulersProvider, taskExecutor, refreshManagerListener)
     }
 
     @After
@@ -67,7 +69,7 @@ class OnlineRepositoryTest {
     fun refresh_hasNeverFetchedData_expectRefreshCall() {
         val refreshResult = Single.just(OnlineRepository.RefreshResult.success())
         `when`(syncStateManager.hasEverFetchedData(requirements.tag)).thenReturn(false)
-        `when`(refreshManager.refresh(repository.fetchFreshData_return, requirements.tag, repository)).thenReturn(refreshResult)
+        `when`(refreshManager.refresh(repository.fetchFreshData_return, requirements.tag, refreshManagerListener)).thenReturn(refreshResult)
 
         repository.requirements = requirements
 
@@ -85,7 +87,7 @@ class OnlineRepositoryTest {
         `when`(syncStateManager.hasEverFetchedData(requirements.tag)).thenReturn(true)
         `when`(syncStateManager.lastTimeFetchedData(requirements.tag)).thenReturn(Date())
         `when`(syncStateManager.isDataTooOld(requirements.tag, repository.maxAgeOfData)).thenReturn(true)
-        `when`(refreshManager.refresh(repository.fetchFreshData_return, requirements.tag, repository)).thenReturn(refreshResult)
+        `when`(refreshManager.refresh(repository.fetchFreshData_return, requirements.tag, refreshManagerListener)).thenReturn(refreshResult)
 
         repository.requirements = requirements
 
@@ -103,7 +105,7 @@ class OnlineRepositoryTest {
         `when`(syncStateManager.hasEverFetchedData(requirements.tag)).thenReturn(true)
         `when`(syncStateManager.lastTimeFetchedData(requirements.tag)).thenReturn(Date())
         // `when`(syncStateManager.isDataTooOld(requirements.tag, repository.maxAgeOfData)).thenReturn(false)
-        `when`(refreshManager.refresh(repository.fetchFreshData_return, requirements.tag, repository)).thenReturn(refreshResult)
+        `when`(refreshManager.refresh(repository.fetchFreshData_return, requirements.tag, refreshManagerListener)).thenReturn(refreshResult)
 
         repository.requirements = requirements
 

--- a/teller/src/test/java/com/levibostian/teller/repository/manager/OnlineRepositoryRefreshManagerTest.kt
+++ b/teller/src/test/java/com/levibostian/teller/repository/manager/OnlineRepositoryRefreshManagerTest.kt
@@ -7,18 +7,20 @@ import com.levibostian.teller.repository.OnlineRepository
 import io.reactivex.subjects.PublishSubject
 import org.junit.Test
 import com.levibostian.teller.util.AssertionUtil.Companion.check
+import com.levibostian.teller.util.Wait
 
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import com.nhaarman.mockito_kotlin.*
 import io.reactivex.subjects.ReplaySubject
+import org.junit.Rule
 
 @RunWith(MockitoJUnitRunner::class)
 class OnlineRepositoryRefreshManagerTest {
 
-    @Mock private lateinit var repo1: OnlineRepository<String, OnlineRepository.GetDataRequirements, String>
-    @Mock private lateinit var repo2: OnlineRepository<String, OnlineRepository.GetDataRequirements, String>
+    @Mock private lateinit var repo1: OnlineRepositoryRefreshManager.Listener
+    @Mock private lateinit var repo2: OnlineRepositoryRefreshManager.Listener
 
     private val defaultTag: GetDataRequirementsTag = "defaultTag"
     private val otherTag: GetDataRequirementsTag = "otherTag"
@@ -56,13 +58,13 @@ class OnlineRepositoryRefreshManagerTest {
                     assertThat(it.didSucceed()).isTrue()
                 })
 
-        verify(repo1).refreshBegin()
-        verify(repo2).refreshBegin()
+        verify(repo1).refreshBegin(defaultTag)
+        verify(repo2).refreshBegin(defaultTag)
 
         val repo1RefreshCompleteArgumentCaptor = argumentCaptor<OnlineRepository.FetchResponse<String>>()
-        verify(repo1).refreshComplete(repo1RefreshCompleteArgumentCaptor.capture())
+        verify(repo1).refreshComplete(eq(defaultTag), repo1RefreshCompleteArgumentCaptor.capture())
         val repo2RefreshCompleteArgumentCaptor = argumentCaptor<OnlineRepository.FetchResponse<String>>()
-        verify(repo2).refreshComplete(repo2RefreshCompleteArgumentCaptor.capture())
+        verify(repo2).refreshComplete(eq(defaultTag), repo2RefreshCompleteArgumentCaptor.capture())
 
         assertThat(repo1RefreshCompleteArgumentCaptor.firstValue).isEqualTo(task1Result)
         assertThat(repo2RefreshCompleteArgumentCaptor.firstValue).isEqualTo(task1Result)
@@ -101,13 +103,13 @@ class OnlineRepositoryRefreshManagerTest {
                     assertThat(it.didFail()).isTrue()
                 })
 
-        verify(repo1).refreshBegin()
-        verify(repo2).refreshBegin()
+        verify(repo1).refreshBegin(defaultTag)
+        verify(repo2).refreshBegin(otherTag)
 
         val repo1RefreshCompleteArgumentCaptor = argumentCaptor<OnlineRepository.FetchResponse<String>>()
-        verify(repo1).refreshComplete(repo1RefreshCompleteArgumentCaptor.capture())
+        verify(repo1).refreshComplete(eq(defaultTag), repo1RefreshCompleteArgumentCaptor.capture())
         val repo2RefreshCompleteArgumentCaptor = argumentCaptor<OnlineRepository.FetchResponse<String>>()
-        verify(repo2).refreshComplete(repo2RefreshCompleteArgumentCaptor.capture())
+        verify(repo2).refreshComplete(eq(otherTag), repo2RefreshCompleteArgumentCaptor.capture())
 
         assertThat(repo1RefreshCompleteArgumentCaptor.firstValue).isEqualTo(task1Result)
         assertThat(repo2RefreshCompleteArgumentCaptor.firstValue).isEqualTo(task2Result)
@@ -146,24 +148,24 @@ class OnlineRepositoryRefreshManagerTest {
                     assertThat(it.didSucceed()).isTrue()
                 })
 
-        verify(repo1).refreshBegin()
+        verify(repo1).refreshBegin(defaultTag)
 
         val repo1RefreshCompleteArgumentCaptor = argumentCaptor<OnlineRepository.FetchResponse<String>>()
-        verify(repo1).refreshComplete(repo1RefreshCompleteArgumentCaptor.capture())
+        verify(repo1).refreshComplete(eq(defaultTag), repo1RefreshCompleteArgumentCaptor.capture())
 
         assertThat(repo1RefreshCompleteArgumentCaptor.firstValue).isEqualTo(task1Result)
     }
 
     @Test
     fun cancelTasksForRepository_oneRepository_refreshTaskGetsCancelled() {
-        var task1Disposed = false
+        val wait = Wait.times(1)
         val task1 = PublishSubject.create<OnlineRepository.FetchResponse<String>>()
                 .doOnDispose {
-                    task1Disposed = true
+                    wait.countDown()
                 }
         val repo1TestObserver = SharedOnlineRepositoryRefreshManager.refresh(task1.singleOrError(), defaultTag, repo1).test()
 
-        verify(repo1).refreshBegin()
+        verify(repo1).refreshBegin(defaultTag)
 
         SharedOnlineRepositoryRefreshManager.cancelTasksForRepository(defaultTag, repo1)
 
@@ -173,18 +175,18 @@ class OnlineRepositoryRefreshManagerTest {
                     assertThat(it.didSkip()).isTrue()
                 })
 
-        assertThat(task1Disposed).isTrue()
+        wait.await()
 
-        verify(repo1, never()).refreshComplete(any<OnlineRepository.FetchResponse<String>>())
+        verify(repo1, never()).refreshComplete(any(), any<OnlineRepository.FetchResponse<String>>())
     }
 
     @Test
     fun cancelTasksForRepository_twoRepositoriesSameTask_refreshTaskContinuesForTaskThatDidNotCancel() {
-        var task1Disposed = false
+        val wait = Wait.times(1)
         val task1Subject = PublishSubject.create<OnlineRepository.FetchResponse<String>>()
         val task1Single = task1Subject
                 .doOnDispose {
-                    task1Disposed = true
+                    wait.countDown()
                 }.singleOrError()
         val task2 = PublishSubject.create<OnlineRepository.FetchResponse<String>>()
 
@@ -194,13 +196,13 @@ class OnlineRepositoryRefreshManagerTest {
         val repo1TestObserver = SharedOnlineRepositoryRefreshManager.refresh(task1Single, defaultTag, repo1).test()
         val repo2TestObserver = SharedOnlineRepositoryRefreshManager.refresh(task2.singleOrError(), defaultTag, repo2).test()
 
-        verify(repo1).refreshBegin()
-        verify(repo2).refreshBegin()
+        verify(repo1).refreshBegin(defaultTag)
+        verify(repo2).refreshBegin(defaultTag)
 
         SharedOnlineRepositoryRefreshManager.cancelTasksForRepository(defaultTag, repo1)
 
         // Continue running task as repo2 is still observing.
-        assertThat(task1Disposed).isFalse()
+        assertThat(wait.notDone()).isTrue()
 
         task1Subject.apply {
             onNext(task1Response)
@@ -225,19 +227,19 @@ class OnlineRepositoryRefreshManagerTest {
                     assertThat(it.didSucceed()).isTrue()
                 })
 
-        verify(repo1, never()).refreshComplete(any<OnlineRepository.FetchResponse<String>>())
+        verify(repo1, never()).refreshComplete(any(), any<OnlineRepository.FetchResponse<String>>())
         val refreshCompleteArgumentCaptor = argumentCaptor<OnlineRepository.FetchResponse<String>>()
-        verify(repo2).refreshComplete(refreshCompleteArgumentCaptor.capture())
+        verify(repo2).refreshComplete(any(), refreshCompleteArgumentCaptor.capture())
         assertThat(refreshCompleteArgumentCaptor.firstValue).isEqualTo(task1Response)
     }
 
     @Test
-    fun cancelTasksForRepository_repoDidNotStartRefresh_ignoreRequest() {
-        var task1Disposed = false
+    fun cancelTasksForRepository_otherRepoThatDidntCallRefresh_ignoreCancelRequest() {
+        val wait = Wait.times(1)
         val task1Subject = PublishSubject.create<OnlineRepository.FetchResponse<String>>()
         val task1Single = task1Subject
                 .doOnDispose {
-                    task1Disposed = true
+                    wait.countDown()
                 }.singleOrError()
 
         val task1Response = OnlineRepository.FetchResponse.success("task1")
@@ -247,8 +249,8 @@ class OnlineRepositoryRefreshManagerTest {
         // Call cancel with same tag, but repo that never started a refresh call.
         SharedOnlineRepositoryRefreshManager.cancelTasksForRepository(defaultTag, repo2)
 
-        // Continue running task as repo2 is still observing.
-        assertThat(task1Disposed).isFalse()
+        // Continue running task as repo1 is still observing refresh task that was started.
+        assertThat(wait.notDone()).isTrue()
 
         task1Subject.apply {
             onNext(task1Response)
@@ -256,14 +258,14 @@ class OnlineRepositoryRefreshManagerTest {
         }
 
         repo1TestObserver
-                .await()
+                .awaitCount(1)
                 .assertValue(check {
                     assertThat(it.didSucceed()).isTrue()
                     assertThat(it.didSkip()).isFalse()
                 })
 
         val refreshCompleteArgumentCaptor = argumentCaptor<OnlineRepository.FetchResponse<String>>()
-        verify(repo1).refreshComplete(refreshCompleteArgumentCaptor.capture())
+        verify(repo1).refreshComplete(any(), refreshCompleteArgumentCaptor.capture())
         assertThat(refreshCompleteArgumentCaptor.firstValue).isEqualTo(task1Response)
     }
 


### PR DESCRIPTION
Instrumentation tests for OnlineRepository have been flaky lately. Through a couple of thrown tests, I realized that async tasks such as fetching of data, saving, observing would all continue beyond disposing. I figured that maybe async tasks from previous tests would complete and call listeners even though .dispose() was called in the @After cleanup.

So, I added functionality to dispose() that would ignore async requests that would come in later and are no longer needed.

Also, I have removed the code not working for code coverage: https://github.com/levibostian/Teller-Android/issues/32#issuecomment-465760940