### PR TITLE
Fix 0.1.0-alpha release to create aar file instead of jar

### DIFF
--- a/teller/build.gradle
+++ b/teller/build.gradle
@@ -109,11 +109,17 @@ task sourcesJar(type: Jar) {
     from android.sourceSets.main.java.sourceFiles
 }
 
-task classesJar(type: Jar) {
-    from "$buildDir/intermediates/classes/release"
+task dokkaJavadoc(type: org.jetbrains.dokka.gradle.DokkaTask) {
+    outputFormat = 'javadoc'
+    outputDirectory = "$buildDir/javadoc"
+}
+
+task javadocJar(type: Jar, dependsOn: dokkaJavadoc) {
+    classifier = 'javadoc'
+    from "$buildDir/javadoc"
 }
 
 artifacts {
-    archives classesJar
     archives sourcesJar
+    archives javadocJar
 }


### PR DESCRIPTION
After creating a 0.1.0-alpha github release and attempting to use the release in one of my Android apps, jitpack generates and downloads a .jar file for my classes instead of generating and download an aar file. 

This resulted in no source code being downloaded into my Android app via gradle unless I appended `@aar` to the end of my `implementation` statement in my `build.gradle` file. 

This has been fixed and tested. I will be deleting the old git tag and creating a new one. 

#non-release